### PR TITLE
Fixing error due to null Nashorn engine

### DIFF
--- a/src/main/java/org/topbraid/shacl/js/NashornScriptEngine.java
+++ b/src/main/java/org/topbraid/shacl/js/NashornScriptEngine.java
@@ -78,7 +78,7 @@ public class NashornScriptEngine implements JSScriptEngine {
 	
 	
 	public NashornScriptEngine() {
-		engine = new ScriptEngineManager().getEngineByName("nashorn");
+		engine = findNashorn();
 		engine.put("TermFactory", new TermFactory());
 		try {
 			engine.eval(ARGS_FUNCTION);
@@ -86,6 +86,17 @@ public class NashornScriptEngine implements JSScriptEngine {
 		catch(ScriptException ex) {
 			ExceptionUtil.throwUnchecked(ex);
 		}
+	}
+
+	private ScriptEngine findNashorn() {
+		ScriptEngine nashorn = new ScriptEngineManager().getEngineByName("nashorn");
+		if (nashorn == null) {
+			nashorn = new ScriptEngineManager(null).getEngineByName("nashorn");
+		}
+		if (nashorn == null) {
+			throw new RuntimeException("Oracle Nashorn not found in the current context");
+		}
+		return nashorn;
 	}
 	
 	


### PR DESCRIPTION
I came across this problem running the library from Scala SBT.

The validator was failing with a null pointer exception. Looking at the source of the error the cause was that nashorn was not being found.

The actual problem seems to be that Scala REPL is doing something to the ScriptEngine factories.
The following code:

```scala
val sm = new javax.script.ScriptEngineManager
println("ENGINES:")
sm.getEngineFactories.forEach(ef => println(ef.getEngineName))
```

Produces the following output where nashorn is missing:

```
ENGINES:
Scala REPL
```

I have been unable to reproduce the error in other JVM based language REPLs (tried JRuby and Kotlin) but even if the issue is Scala specific, the problem can be easily solved by looking in the standard factories, [passing a null parameter to the constructor](https://docs.oracle.com/javase/7/docs/api/javax/script/ScriptEngineManager.html#ScriptEngineManager(java.lang.ClassLoader)) if the standard mechanism fails.