### PR TITLE
Configuration object and partial validation

### DIFF
--- a/src/main/java/org/topbraid/shacl/engine/ConfigurableEngine.java
+++ b/src/main/java/org/topbraid/shacl/engine/ConfigurableEngine.java
@@ -1,0 +1,8 @@
+package org.topbraid.shacl.engine;
+
+import org.topbraid.shacl.validation.ValidationEngineConfiguration;
+
+public interface ConfigurableEngine {
+    public ValidationEngineConfiguration getConfiguration();
+    public void setConfiguration(ValidationEngineConfiguration configuration);
+}

--- a/src/main/java/org/topbraid/shacl/testcases/GraphValidationTestCaseType.java
+++ b/src/main/java/org/topbraid/shacl/testcases/GraphValidationTestCaseType.java
@@ -35,13 +35,9 @@ import org.topbraid.jenax.util.JenaDatatypes;
 import org.topbraid.jenax.util.JenaUtil;
 import org.topbraid.shacl.arq.SHACLPaths;
 import org.topbraid.shacl.engine.ShapesGraph;
-import org.topbraid.shacl.engine.filters.ExcludeMetaShapesFilter;
 import org.topbraid.shacl.util.ModelPrinter;
 import org.topbraid.shacl.util.SHACLUtil;
-import org.topbraid.shacl.validation.ValidationEngine;
-import org.topbraid.shacl.validation.ValidationEngineFactory;
-import org.topbraid.shacl.validation.ValidationSuggestionGenerator;
-import org.topbraid.shacl.validation.ValidationSuggestionGeneratorFactory;
+import org.topbraid.shacl.validation.*;
 import org.topbraid.shacl.vocabulary.DASH;
 import org.topbraid.shacl.vocabulary.SH;
 
@@ -100,10 +96,13 @@ public class GraphValidationTestCaseType implements TestCaseType {
 			URI shapesGraphURI = SHACLUtil.withShapesGraph(dataset);
 
 			ShapesGraph shapesGraph = new ShapesGraph(dataset.getNamedModel(shapesGraphURI.toString()));
+
+			ValidationEngineConfiguration configuration = new ValidationEngineConfiguration();
 			if(!getResource().hasProperty(DASH.validateShapes, JenaDatatypes.TRUE)) {
-				shapesGraph.setShapeFilter(new ExcludeMetaShapesFilter());
+				configuration.setValidateShapes(false);
 			}
 			ValidationEngine validationEngine = ValidationEngineFactory.get().create(dataset, shapesGraphURI, shapesGraph, null);
+			validationEngine.setConfiguration(configuration);
 			validationEngine.applyEntailments();
 			Resource actualReport = validationEngine.validateAll();
 			Model actualResults = actualReport.getModel();

--- a/src/main/java/org/topbraid/shacl/testcases/W3CTestRunner.java
+++ b/src/main/java/org/topbraid/shacl/testcases/W3CTestRunner.java
@@ -50,6 +50,7 @@ import org.topbraid.shacl.engine.filters.CoreConstraintFilter;
 import org.topbraid.shacl.engine.filters.ExcludeMetaShapesFilter;
 import org.topbraid.shacl.util.ModelPrinter;
 import org.topbraid.shacl.validation.ValidationEngine;
+import org.topbraid.shacl.validation.ValidationEngineConfiguration;
 import org.topbraid.shacl.validation.ValidationEngineFactory;
 import org.topbraid.shacl.vocabulary.DASH;
 import org.topbraid.shacl.vocabulary.MF;
@@ -242,11 +243,12 @@ public class W3CTestRunner {
 			dataset.addNamedModel(shapesGraphURI.toString(), shapesModel);
 
 			ShapesGraph shapesGraph = new ShapesGraph(shapesModel);
-			shapesGraph.setShapeFilter(new ExcludeMetaShapesFilter());
+			ValidationEngineConfiguration configuration = new ValidationEngineConfiguration().setValidateShapes(false);
 			if(entry.hasProperty(ResourceFactory.createProperty(MF.NS + "requires"), SHT.CoreOnly)) {
 				shapesGraph.setConstraintFilter(new CoreConstraintFilter());
 			}
 			ValidationEngine engine = ValidationEngineFactory.get().create(dataset, shapesGraphURI, shapesGraph, null);
+			engine.setConfiguration(configuration);
 			try {
 				Resource actualReport = engine.validateAll();
 				Model actualResults = actualReport.getModel();

--- a/src/main/java/org/topbraid/shacl/validation/MaximumNumberViolations.java
+++ b/src/main/java/org/topbraid/shacl/validation/MaximumNumberViolations.java
@@ -1,0 +1,5 @@
+package org.topbraid.shacl.validation;
+
+public class MaximumNumberViolations extends RuntimeException {
+    public MaximumNumberViolations(int violationCount) { super("Maximum number of violations (" + violationCount + ") reached"); }
+}

--- a/src/main/java/org/topbraid/shacl/validation/ValidationEngineConfiguration.java
+++ b/src/main/java/org/topbraid/shacl/validation/ValidationEngineConfiguration.java
@@ -1,0 +1,47 @@
+package org.topbraid.shacl.validation;
+
+/**
+ * Configures the behaviour of the validation engine
+ */
+public class ValidationEngineConfiguration {
+
+    // By default collect all possible errors
+    private int validationErrorBatch = -1;
+
+    // By default validate shapes
+    private boolean validateShapes = true;
+
+    /**
+     * Maximum number of validations before returning the report
+     * @return number of validations or -1 to mean all validations
+     */
+    public int getValidationErrorBatch() {
+        return validationErrorBatch;
+    }
+
+    /**
+     * Set the maximum number of validations before returning the rpoert
+     * @param validationErrorBatch maximum number of validations or -1 for all validations
+     * @return  current configuration after modification
+     */
+    public ValidationEngineConfiguration setValidationErrorBatch(int validationErrorBatch) {
+        this.validationErrorBatch = validationErrorBatch;
+        return this;
+    }
+
+    /**
+     * Should the engine validates shapes
+     * @return boolean flag for shapes validation
+     */
+    public boolean getValidateShapes() { return validateShapes; }
+
+    /**
+     * Sets an option for the engine to validate shapes
+     * @param validateShapes boolean flat indicating if shapes must be validated
+     * @return current configuration after modification
+     */
+    public ValidationEngineConfiguration setValidateShapes(boolean validateShapes) {
+        this.validateShapes = validateShapes;
+        return this;
+    }
+}

--- a/src/main/java/org/topbraid/shacl/validation/ValidationUtil.java
+++ b/src/main/java/org/topbraid/shacl/validation/ValidationUtil.java
@@ -41,8 +41,12 @@ import org.topbraid.shacl.vocabulary.TOSH;
  */
 public class ValidationUtil {
 
-	
+
 	public static ValidationEngine createValidationEngine(Model dataModel, Model shapesModel, boolean validateShapes) {
+		return createValidationEngine(dataModel, shapesModel, new ValidationEngineConfiguration().setValidateShapes(validateShapes));
+	}
+
+	public static ValidationEngine createValidationEngine(Model dataModel, Model shapesModel, ValidationEngineConfiguration configuration) {
 		// Ensure that the SHACL, DASH and TOSH graphs are present in the shapes Model
 		if(!shapesModel.contains(TOSH.hasShape, RDF.type, (RDFNode)null)) { // Heuristic
 			Model unionModel = SHACLSystemModel.getSHACLModel();
@@ -55,7 +59,7 @@ public class ValidationUtil {
 
 		// Make sure all sh:Functions are registered
 		SHACLFunctions.registerFunctions(shapesModel);
-		
+
 		// Create Dataset that contains both the data model and the shapes model
 		// (here, using a temporary URI for the shapes graph)
 		URI shapesGraphURI = URI.create("urn:x-shacl-shapes-graph:" + UUID.randomUUID().toString());
@@ -63,13 +67,13 @@ public class ValidationUtil {
 		dataset.addNamedModel(shapesGraphURI.toString(), shapesModel);
 
 		ShapesGraph shapesGraph = new ShapesGraph(shapesModel);
-		if(!validateShapes) {
-			shapesGraph.setShapeFilter(new ExcludeMetaShapesFilter());
-		}
-		return ValidationEngineFactory.get().create(dataset, shapesGraphURI, shapesGraph, null);
+
+		ValidationEngine engine = ValidationEngineFactory.get().create(dataset, shapesGraphURI, shapesGraph, null);
+		engine.setConfiguration(configuration);
+		return engine;
 	}
 
-	
+
 	/**
 	 * Validates a given data Model against all shapes from a given shapes Model.
 	 * If the shapesModel does not include the system graph triples then these will be added.
@@ -80,8 +84,22 @@ public class ValidationUtil {
 	 * @return an instance of sh:ValidationReport in a results Model
 	 */
 	public static Resource validateModel(Model dataModel, Model shapesModel, boolean validateShapes) {
-		
-		ValidationEngine engine = createValidationEngine(dataModel, shapesModel, validateShapes);
+		return validateModel(dataModel, shapesModel, new ValidationEngineConfiguration().setValidateShapes(validateShapes));
+	}
+
+	/**
+	 * Validates a given data Model against all shapes from a given shapes Model.
+	 * If the shapesModel does not include the system graph triples then these will be added.
+	 * Entailment regimes are applied prior to validation.
+	 * @param dataModel  the data Model
+	 * @param shapesModel  the shapes Model
+	 * @param configuration  configuration for the validation engine
+	 * @return an instance of sh:ValidationReport in a results Model
+	 */
+	public static Resource validateModel(Model dataModel, Model shapesModel, ValidationEngineConfiguration configuration) {
+
+		ValidationEngine engine = createValidationEngine(dataModel, shapesModel, configuration);
+		engine.setConfiguration(configuration);
 		try {
 			engine.applyEntailments();
 			return engine.validateAll();

--- a/src/test/java/org/topbraid/shacl/TestValidatorConfiguration.java
+++ b/src/test/java/org/topbraid/shacl/TestValidatorConfiguration.java
@@ -1,0 +1,36 @@
+package org.topbraid.shacl;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.util.FileUtils;
+import org.junit.Test;
+import org.topbraid.jenax.util.JenaUtil;
+import org.topbraid.shacl.validation.ValidationEngineConfiguration;
+import org.topbraid.shacl.validation.ValidationUtil;
+import org.topbraid.shacl.vocabulary.SH;
+
+public class TestValidatorConfiguration {
+
+    @Test
+    public void testMaxErrors() {
+        Model dataModel = JenaUtil.createMemoryModel();
+        dataModel.read(ValidationExample.class.getResourceAsStream("/sh/tests/core/property/class-001.test.ttl"), "urn:dummy", FileUtils.langTurtle);
+
+        ValidationEngineConfiguration configuration = new ValidationEngineConfiguration();
+        configuration.setValidationErrorBatch(-1);
+
+        Resource reportNoMaximum = ValidationUtil.validateModel(dataModel, dataModel, configuration);
+
+        Model resultModel = reportNoMaximum.getModel();
+        assert(resultModel.listStatements(null, SH.resultSeverity, SH.Violation).toList().size() == 2);
+
+
+        configuration.setValidationErrorBatch(1);
+        Resource reportMaximum = ValidationUtil.validateModel(dataModel, dataModel, configuration);
+
+        resultModel = reportMaximum.getModel();
+        System.out.println("FOUND " + resultModel.listStatements(null, SH.resultSeverity, SH.Violation).toList().size() );
+        assert(resultModel.listStatements(null, SH.resultSeverity, SH.Violation).toList().size() == 1);
+
+    }
+}


### PR DESCRIPTION
This PR introduces a configuration option for the validation engine making it possible to stop the evaluation of the constraints, once a maximum number of errors have been reached.

The use case for this behaviour is situations where we just need to know if the data graph is valid or not, regardless of the total number of errors. For example, where providing a validity service where we want to maximise the performance of the service and where failing fast is preferred to getting the complete set of validation errors.

To make it possible to configure this behaviour, a configuration object has been introduced where this option (and other future options) can be set-up.

Matching JS change: https://github.com/TopQuadrant/shacl-js/pull/16