### PR TITLE
Upgrade jena to 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <ver.jena>3.7.0</ver.jena>
+    <ver.jena>3.8.0</ver.jena>
     <ver.junit>4.12</ver.junit>
     <ver.slf4j>1.7.25</ver.slf4j>
     <ver.log4j1>1.2.17</ver.log4j1>


### PR DESCRIPTION
Change Jena version to 3.8.0 because of two security issues:
- First issue was the dependency with xerces (https://nvd.nist.gov/vuln/detail/CVE-2013-4002), and the dependency is removed in the upgrade.
- Second issue is with jackson dependency (https://github.com/FasterXML/jackson-databind/issues/1599) which is updated to 2.9.5 and if default types are not used, it's not a security issue.