### PR TITLE
Added targetCount to the report

### DIFF
--- a/src/main/java/org/topbraid/shacl/testcases/GraphValidationTestCaseType.java
+++ b/src/main/java/org/topbraid/shacl/testcases/GraphValidationTestCaseType.java
@@ -40,11 +40,13 @@ import org.topbraid.shacl.util.SHACLUtil;
 import org.topbraid.shacl.validation.*;
 import org.topbraid.shacl.vocabulary.DASH;
 import org.topbraid.shacl.vocabulary.SH;
+import org.topbraid.shacl.vocabulary.SHEXT;
 
 public class GraphValidationTestCaseType implements TestCaseType {
 
 	public final static List<Property> IGNORED_PROPERTIES = Arrays.asList(new Property[] {
 		SH.message, // For TopBraid's suggestions
+		SHEXT.targetCount, // TODO: Find a way to add an SPARQL statement to check this
 		SH.resultMessage,
 		DASH.suggestionGroup
 	});

--- a/src/main/java/org/topbraid/shacl/vocabulary/SHEXT.java
+++ b/src/main/java/org/topbraid/shacl/vocabulary/SHEXT.java
@@ -1,0 +1,38 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  See the NOTICE file distributed with this work for additional
+ *  information regarding copyright ownership.
+ */
+package org.topbraid.shacl.vocabulary;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.ResourceFactory;
+
+/**
+ * Vocabulary extension from http://www.w3.org/ns/shacl#
+ */
+public class SHEXT {
+
+    public final static String BASE_URI = "http://www.w3.org/ns/shacl/report/extended#";
+
+    public final static String NS = BASE_URI;
+
+    public final static String PREFIX = "sh";
+
+    public final static Property targetCount = ResourceFactory.createProperty(NS + "targetCount");
+
+    public static String getURI() {
+        return NS;
+    }
+}


### PR DESCRIPTION
Fixes #38

I did not find any predicate on the SHACL vocabulary to return the count of targeted shapes on the `ValidationReport`, so I created a new vocabulary to express this.

I haven't found the way to add a the proper tests for this value in the report using a SPARQL query (like is done for the others) because of my lack of expertise on that side.
