### PR TITLE
Added the possibility to pass your own ValidationEngine constructor

### DIFF
--- a/src/main/java/org/topbraid/shacl/validation/ValidationEngineConfiguration.java
+++ b/src/main/java/org/topbraid/shacl/validation/ValidationEngineConfiguration.java
@@ -13,6 +13,9 @@ public class ValidationEngineConfiguration {
 
     // By default collect all possible errors
     private int validationErrorBatch = -1;
+
+    // By default use the ValidationEngineFactory to construct a ValidationEngine
+    private ValidationEngineConstructor engineConstructor = ValidationEngineFactory.get();
     
     
     /**
@@ -66,6 +69,24 @@ public class ValidationEngineConfiguration {
      */
     public ValidationEngineConfiguration setValidateShapes(boolean validateShapes) {
         this.validateShapes = validateShapes;
+        return this;
+    }
+
+    /**
+     * The customized ValidationEngine constructor
+     * @return boolean flag for shapes validation
+     */
+    public ValidationEngineConstructor getEngineConstructor() {
+        return engineConstructor;
+    }
+
+    /**
+     * Sets an option for constructing a customized ValidationEngine
+     * @param engineConstructor the template to construct ValidationEngine
+     * @return current configuration after modification
+     */
+    public ValidationEngineConfiguration setEngineConstructor(ValidationEngineConstructor engineConstructor) {
+        this.engineConstructor = engineConstructor;
         return this;
     }
 }

--- a/src/main/java/org/topbraid/shacl/validation/ValidationEngineConstructor.java
+++ b/src/main/java/org/topbraid/shacl/validation/ValidationEngineConstructor.java
@@ -1,0 +1,22 @@
+package org.topbraid.shacl.validation;
+
+import org.apache.jena.query.Dataset;
+import org.apache.jena.rdf.model.Resource;
+import org.topbraid.shacl.engine.ShapesGraph;
+
+import java.net.URI;
+
+/**
+ * Interface to construct a ValidationEngine.
+ */
+public interface ValidationEngineConstructor {
+    /**
+     * Constructs a new ValidationEngine.
+     * @param dataset  the Dataset to operate on
+     * @param shapesGraphURI  the URI of the shapes graph (must be in the dataset)
+     * @param shapesGraph  the ShapesGraph with the shapes to validate against
+     * @param report  the sh:ValidationReport object in the results Model, or null to create a new one
+     * @return a new ValidationEngine
+     */
+    ValidationEngine create(Dataset dataset, URI shapesGraphURI, ShapesGraph shapesGraph, Resource report);
+}

--- a/src/main/java/org/topbraid/shacl/validation/ValidationEngineFactory.java
+++ b/src/main/java/org/topbraid/shacl/validation/ValidationEngineFactory.java
@@ -30,7 +30,7 @@ import org.topbraid.shacl.engine.ShapesGraph;
  * 
  * @author Holger Knublauch
  */
-public class ValidationEngineFactory {
+public class ValidationEngineFactory implements ValidationEngineConstructor {
 
 	private static ValidationEngineFactory singleton = new ValidationEngineFactory();
 	

--- a/src/main/java/org/topbraid/shacl/validation/ValidationUtil.java
+++ b/src/main/java/org/topbraid/shacl/validation/ValidationUtil.java
@@ -68,7 +68,7 @@ public class ValidationUtil {
 
 		ShapesGraph shapesGraph = new ShapesGraph(shapesModel);
 
-		ValidationEngine engine = ValidationEngineFactory.get().create(dataset, shapesGraphURI, shapesGraph, null);
+		ValidationEngine engine = configuration.getEngineConstructor().create(dataset, shapesGraphURI, shapesGraph, null);
 		engine.setConfiguration(configuration);
 		return engine;
 	}


### PR DESCRIPTION
Since there are [possible scenarios](https://github.com/TopQuadrant/shacl/pull/40#issuecomment-408735686) where one wants to customise the `ValidationEngine`, it would be very useful to be able to specify a "constructor" in the `ValidationEngineConfiguration`.
`ValidationUtil` makes use of it and from the client side there is minimal code to add.