### PR TITLE
restore closed shape message

### DIFF
--- a/src/main/java/org/topbraid/shacl/validation/java/ClosedConstraintExecutor.java
+++ b/src/main/java/org/topbraid/shacl/validation/java/ClosedConstraintExecutor.java
@@ -48,7 +48,7 @@ class ClosedConstraintExecutor extends AbstractNativeConstraintExecutor {
 					while(it.hasNext()) {
 						Statement s = it.next();
 						if(!allowedProperties.contains(s.getPredicate())) {
-							Resource result = engine.createValidationResult(constraint, focusNode, s.getObject(), () -> "Unexpected value for property " + engine.getLabelFunction().apply(s.getPredicate()));
+							Resource result = engine.createValidationResult(constraint, focusNode, s.getObject(), () -> "Predicate " + engine.getLabelFunction().apply(s.getPredicate()) + " is not allowed (closed shape)");
 							result.removeAll(SH.resultPath);
 							result.addProperty(SH.resultPath, s.getPredicate());
 						}


### PR DESCRIPTION
I find the message "Unexpected value for property ex:myProperty" less clear than previously the message "Predicate ex:myProperty is not allowed (closed shape)".

First, it's not the particular value that is unexpected, but that there is a value for that property at all. Second, I like that previously the reason "closed shape" was given.