### PR TITLE
References to additional services using TopBraid

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Coverage:
 * [SHACL JavaScript Extensions](https://www.w3.org/TR/shacl-js/)
 * [SHACL Compact Syntax](https://w3c.github.io/shacl/shacl-compact-syntax/)
 
-This [Online SHACL Shape Validator](https://www.itb.ec.europa.eu/shacl/shacl/upload) uses the TopBraid SHACL API internally.
+The TopBraid SHACL API is internally used by the European Commission's generic [SHACL-based RDF validator](https://www.itb.ec.europa.eu/shacl/any/upload) (used to validate RDF content against SHACL shapes)
+and [SHACL shape validator](https://www.itb.ec.europa.eu/shacl/shacl/upload) (used to validate SHACL shapes themselves).
 
 The same code is used in the TopBraid products (currently aligned with the TopBraid 6.3 release).
 


### PR DESCRIPTION
Extended the reference to the SHACL shape validator (i.e. the validator for the shapes themselves) to also reference a generic RDF validator based on SHACL shapes. Both use TopBraid internally and would be useful as references in the README.