### PR TITLE
Update to Jena 4.2.0 to resolve CVE-2021-39239

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <ver.jena>4.1.0</ver.jena>
+    <ver.jena>4.2.0</ver.jena>
     <ver.junit>4.13.2</ver.junit>
     <ver.antlr>4.5.3</ver.antlr>
     <ver.slf4j>1.7.30</ver.slf4j>


### PR DESCRIPTION
Got a notification from our dependency vulnerability checking on the use of Jena prior to version 4.2.0 (see [CVE-2021-39239](https://nvd.nist.gov/vuln/detail/CVE-2021-39239). This should be an easy merge as TopBraid is already using Jena 4.1.0 and from my side building and running unit tests didn't produce any issues.

If this is approved and merged, would it be possible to have a TopBraid release made? We depend on TopBraid plus Jena but the published TopBraid 1.3.2 release still depends on Jena 3.13.1. Thanks!