### PR TITLE
Updated topbraid SHACL library to remove deprecated Apache Jena calls…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.topbraid</groupId>
   <artifactId>shacl</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.4.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>TopBraid SHACL API</name>
@@ -68,7 +68,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <ver.jena>4.2.0</ver.jena>
+    <ver.jena>4.3.1</ver.jena>
     <ver.junit>4.13.2</ver.junit>
     <ver.slf4j>1.7.30</ver.slf4j>
     <ver.log4j2>2.16.0</ver.log4j2>

--- a/src/main/java/org/topbraid/jenax/util/DelegatingDataset.java
+++ b/src/main/java/org/topbraid/jenax/util/DelegatingDataset.java
@@ -19,10 +19,10 @@ package org.topbraid.jenax.util;
 import java.util.Iterator;
 
 import org.apache.jena.query.Dataset;
-import org.apache.jena.query.LabelExistsException;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.shared.Lock;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.util.Context;
@@ -44,7 +44,7 @@ public class DelegatingDataset implements Dataset {
 
 	
 	@Override
-	public Dataset addNamedModel(String uri, Model model) throws LabelExistsException {
+	public Dataset addNamedModel(String uri, Model model) { //throws LabelExistsException {
 		delegate.addNamedModel(uri, model);
 		return this;
 	}
@@ -200,4 +200,40 @@ public class DelegatingDataset implements Dataset {
     public ReadWrite transactionMode() {
         return delegate.transactionMode();
     }
+
+
+	@Override
+	public Model getNamedModel(Resource uri) {
+		return delegate.getNamedModel(uri);
+	}
+
+
+	@Override
+	public boolean containsNamedModel(Resource uri) {
+		return delegate.containsNamedModel(uri);
+	}
+
+
+	@Override
+	public Dataset addNamedModel(Resource resource, Model model) {
+		return delegate.addNamedModel(resource, model);
+	}
+
+
+	@Override
+	public Dataset removeNamedModel(Resource resource) {
+		return delegate.removeNamedModel(resource);
+	}
+
+
+	@Override
+	public Dataset replaceNamedModel(Resource resource, Model model) {
+		return delegate.replaceNamedModel(resource, model);
+	}
+
+
+	@Override
+	public Iterator<Resource> listModelNames() {
+		return delegate.listModelNames();
+	}
 }

--- a/src/main/java/org/topbraid/jenax/util/JenaUtil.java
+++ b/src/main/java/org/topbraid/jenax/util/JenaUtil.java
@@ -60,7 +60,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.engine.binding.BindingHashMap;
+import org.apache.jena.sparql.engine.binding.BindingBuilder;
 import org.apache.jena.sparql.engine.binding.BindingRoot;
 import org.apache.jena.sparql.expr.E_Function;
 import org.apache.jena.sparql.expr.Expr;
@@ -202,16 +202,17 @@ public class JenaUtil {
 	 */
 	public static Binding asBinding(final QuerySolution map) {
 		if(map != null) {
-			BindingHashMap result = new BindingHashMap();
+			BindingBuilder builder = Binding.builder();
+			//BindingHashMap result = new BindingHashMap();
 			Iterator<String> varNames = map.varNames();
 			while(varNames.hasNext()) {
 				String varName = varNames.next();
 				RDFNode node = map.get(varName);
 				if(node != null) {
-					result.add(Var.alloc(varName), node.asNode());
+					builder.add(Var.alloc(varName), node.asNode());
 				}
 			}
-			return result;
+			return builder.build();
 		}
 		else {
 			return null;

--- a/src/main/java/org/topbraid/shacl/arq/SHACLFunctionsCache.java
+++ b/src/main/java/org/topbraid/shacl/arq/SHACLFunctionsCache.java
@@ -19,7 +19,6 @@ package org.topbraid.shacl.arq;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Dataset;

--- a/src/main/java/org/topbraid/shacl/arq/SHACLPaths.java
+++ b/src/main/java/org/topbraid/shacl/arq/SHACLPaths.java
@@ -69,7 +69,7 @@ public class SHACLPaths {
 	
 	public static void addValueNodes(RDFNode focusNode, Path path, Collection<RDFNode> results) {
 		Set<Node> seen = new HashSet<>();
-		Iterator<Node> it = PathEval.eval(focusNode.getModel().getGraph(), focusNode.asNode(), path, Context.emptyContext);
+		Iterator<Node> it = PathEval.eval(focusNode.getModel().getGraph(), focusNode.asNode(), path, Context.emptyContext());
 		while(it.hasNext()) {
 			Node node = it.next();
 			if(!seen.contains(node)) {

--- a/src/main/java/org/topbraid/shacl/expr/lib/FunctionExpression.java
+++ b/src/main/java/org/topbraid/shacl/expr/lib/FunctionExpression.java
@@ -28,7 +28,8 @@ import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.ExecutionContext;
-import org.apache.jena.sparql.engine.binding.BindingHashMap;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.binding.BindingBuilder;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprEvalException;
 import org.apache.jena.sparql.expr.NodeValue;
@@ -139,15 +140,17 @@ public class FunctionExpression extends ComplexNodeExpression {
 			for(int x = 0; x < total; x++) {
 				
 				int y = x;
-				BindingHashMap binding = new BindingHashMap();
+				BindingBuilder builder = Binding.builder();
+				//BindingHashMap binding = new BindingHashMap();
 				for(int i = 0; i < args.size(); i++) {
 					List<RDFNode> a = as.get(i);
 					if(!a.isEmpty()) {
 						int m = y % a.size();
-						binding.add(Var.alloc("a" + i), a.get(m).asNode());
+						builder.add(Var.alloc("a" + i), a.get(m).asNode());
 						y /= a.size();
 					}
 				}
+				Binding binding = builder.build();
 				
 				Dataset dataset = context.getDataset();
 				DatasetGraph dsg = dataset.asDatasetGraph();

--- a/src/main/java/org/topbraid/shacl/validation/ValidationEngine.java
+++ b/src/main/java/org/topbraid/shacl/validation/ValidationEngine.java
@@ -386,7 +386,7 @@ public class ValidationEngine extends AbstractEngine {
 				return results;					
 			}
 			Set<RDFNode> results = new HashSet<>();
-			Iterator<Node> it = PathEval.eval(focusNode.getModel().getGraph(), focusNode.asNode(), jenaPath, Context.emptyContext);
+			Iterator<Node> it = PathEval.eval(focusNode.getModel().getGraph(), focusNode.asNode(), jenaPath, Context.emptyContext());
 			while(it.hasNext()) {
 				Node node = it.next();
 				results.add(focusNode.getModel().asRDFNode(node));


### PR DESCRIPTION
… and updated version of Jena to 4.3.1

The built in junit tests all pass although I'm not sure there's 100% coverage over all calls, particularly HTTP related SPARQL queries where there were more changes in the underlying Jena APIs and swap of Apache HttpClient for java.net.http.HttpClient