### PR TITLE
Lightweight Docker image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,46 @@
+FROM eclipse-temurin:11 as jre-build
+WORKDIR /app
+
+# Version can be specified at build time
+ARG VERSION=1.4.2
+
+# Annotations to embed in container
+LABEL org.opencontainers.image.title="TopBraid SHACL API"
+LABEL org.opencontainers.image.description="SHACL API in Java based on Apache Jena "
+LABEL org.opencontainers.image.source=https://github.com/TopQuadrant/shacl
+LABEL org.opencontainers.image.licenses=Apache-2.0
+LABEL org.opencontainers.image.version=${VERSION}
+
+# BUILD STAGE 1: install minimal Java environment + curl & zip for SHACL API
+
+# Create a custom Java runtime
+RUN $JAVA_HOME/bin/jlink \
+         --add-modules java.base,java.compiler,java.desktop,java.management,java.naming,java.net.http,java.rmi,java.scripting,java.security.jgss,java.security.sasl,java.sql,java.xml.crypto,jdk.unsupported \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+RUN apt-get -y update && \
+    apt-get -y install curl zip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and unpack binary version for appropriate release
+RUN curl -s https://repo1.maven.org/maven2/org/topbraid/shacl/${VERSION}/shacl-${VERSION}-bin.zip > shacl.zip
+RUN unzip shacl.zip && rm shacl.zip
+
+# BUILD STAGE 2: keep only Java and SHACL
+
+FROM ubuntu:jammy
+
+ARG VERSION=1.4.2
+
+ENV JAVA_HOME=/usr
+ENV PATH "/app/shacl-${VERSION}/bin:${PATH}"
+
+COPY --from=jre-build /javaruntime $JAVA_HOME
+COPY --chmod=0755 --from=jre-build /app/shacl-${VERSION} /app/shacl-${VERSION}
+COPY --chmod=0755 "entrypoint.sh" "/entrypoint.sh"
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+# add conditions to either use "validate" or "infer"
+# as commands, otherwise print a help statement
+
+if [ $1 == validate ] ; then
+	set -- shaclvalidate.sh "$@"
+elif [ $1 == infer ] ; then
+	set -- shaclinfer.sh "$@"
+else
+	cat << EOF
+Please use this docker image as follows:
+docker run -v /path/to/data:/data IMAGE [COMMAND] [PARAMETERS]
+COMMAND:
+	validate 
+		to run validation
+	infer
+		to run rule inferencing
+PARAMETER:
+	-datafile /data/myfile.ttl [MANDATORY]
+		input to be validated (only .ttl format supported)
+	-shapesfile /data/myshapes.ttl [OPTIONAL]
+		shapes for validation (only .ttl format supported)
+EOF
+	exit 1
+fi
+
+exec "$@"

--- a/README.md
+++ b/README.md
@@ -86,26 +86,26 @@ The tools print the validation report or the inferences graph to the output scre
 The `Dockerfile` in the `.docker` folder includes a minimal Java Runtime Environment for the SHACL API that clocks in at 144Mb. To build the docker imageß use:
 
 ```
-docker build -t shacl_API .docker/
+docker build -t topquadrant/shacl:1.4.2 .docker/
 ```
 
 To use the Docker image, there are two possible commands. To run the validator:
 
 ```
-docker run --rm -v /path/to/data:/data shacl_API validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+docker run --rm -v /path/to/data:/data topquadrant/shacl:1.4.2 validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
 ```
 
 To run rule inferencing:
 
 ```
-docker run --rm -v /path/to/data:/data shacl_API infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+docker run --rm -v /path/to/data:/data topquadrant/shacl:1.4.2 infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
 ```
 
-Any other command after `IMAGE_ID` will print the following help page:
+Any other command after `topquadrant/shacl:1.4.2` will print the following help page:
 
 ```
 Please use this docker image as follows:
-docker run -v /path/to/data:/data shacl_API [COMMAND] [PARAMETERS]
+docker run -v /path/to/data:/data topquadrant/shacl:1.4.2 [COMMAND] [PARAMETERS]
 COMMAND:
 	validate 
 		to run validation

--- a/README.md
+++ b/README.md
@@ -80,3 +80,40 @@ Add -validateShapes in case you want to include the metashapes (from the tosh na
 Currently only Turtle (.ttl) files are supported.
 
 The tools print the validation report or the inferences graph to the output screen.
+
+## Dockerfile Usage
+
+The `Dockerfile` in the `.docker` folder includes a minimal Java Runtime Environment for the SHACL API that clocks in at 144Mb. To build the docker use:
+
+```
+docker build -t shacl_API .docker/
+```
+
+To use the Docker image, there are two possible commands. To run the validator:
+
+```
+docker run --rm -v /path/to/data:/data IMAGE_ID validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+```
+
+To run rule inferencing:
+
+```
+docker run --rm -v /path/to/data:/data IMAGE_ID infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+```
+
+Any other command after `IMAGE_ID` will print the following help page:
+
+```
+Please use this docker image as follows:
+docker run -v /path/to/data:/data IMAGE [COMMAND] [PARAMETERS]
+COMMAND:
+	validate 
+		to run validation
+	infer
+		to run rule inferencing
+PARAMETERS:
+	-datafile /data/myfile.ttl [MANDATORY]
+		input to be validated (only .ttl format supported)
+	-shapesfile /data/myshapes.ttl [OPTIONAL]
+		shapes for validation (only .ttl format supported)
+```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The tools print the validation report or the inferences graph to the output scre
 
 ## Dockerfile Usage
 
-The `Dockerfile` in the `.docker` folder includes a minimal Java Runtime Environment for the SHACL API that clocks in at 144Mb. To build the docker use:
+The `Dockerfile` in the `.docker` folder includes a minimal Java Runtime Environment for the SHACL API that clocks in at 144Mb. To build the docker imageß use:
 
 ```
 docker build -t shacl_API .docker/
@@ -92,20 +92,20 @@ docker build -t shacl_API .docker/
 To use the Docker image, there are two possible commands. To run the validator:
 
 ```
-docker run --rm -v /path/to/data:/data IMAGE_ID validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+docker run --rm -v /path/to/data:/data shacl_API validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
 ```
 
 To run rule inferencing:
 
 ```
-docker run --rm -v /path/to/data:/data IMAGE_ID infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+docker run --rm -v /path/to/data:/data shacl_API infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
 ```
 
 Any other command after `IMAGE_ID` will print the following help page:
 
 ```
 Please use this docker image as follows:
-docker run -v /path/to/data:/data IMAGE [COMMAND] [PARAMETERS]
+docker run -v /path/to/data:/data shacl_API [COMMAND] [PARAMETERS]
 COMMAND:
 	validate 
 		to run validation


### PR DESCRIPTION
Dear Holger,

your SHACL API tool is very nicely implemented and this PR includes a Dockerfile to make the tool even more accessible. The Dockerfile includes a multi-stage build to ensure that only a minimal Java environment is created to support Jena for the SHACL API. To find out about the minimal requirements, the Apache Jena developers [provided all the information and tools needed](https://github.com/apache/jena/issues/1760) for this task. 

The current `Dockerfile` creates an image of 144Mb, making it relatively lightweight. This `Dockerfile` is linked to an `entrypoint.sh` script to call either `shaclvalidate.sh` or `shaclinfer.sh` with the commands `validate` and `infer` respectively. I modified the README to explain the usage as follows:

## Dockerfile Usage

The `Dockerfile` in the `.docker` folder includes a minimal Java Runtime Environment for the SHACL API that clocks in at 144Mb. To build the docker image use:

```
docker build -t topquadrant/shacl:1.4.2 .docker/
```

To use the Docker image, there are two possible commands. To run the validator:

```
docker run --rm -v /path/to/data:/data topquadrant/shacl:1.4.2 validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
```

To run rule inferencing:

```
docker run --rm -v /path/to/data:/data topquadrant/shacl:1.4.2 infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
```

Any other command after `topquadrant/shacl:1.4.2` will print the following help page:

```
Please use this docker image as follows:
docker run -v /path/to/data:/data shacl_API [COMMAND] [PARAMETERS]
COMMAND:
	validate 
		to run validation
	infer
		to run rule inferencing
PARAMETERS:
	-datafile /data/myfile.ttl [MANDATORY]
		input to be validated (only .ttl format supported)
	-shapesfile /data/myshapes.ttl [OPTIONAL]
		shapes for validation (only .ttl format supported)
```
The current PR would already be a fully working Docker solution for `shacl-1.4.2`, but there could be another major improvement to this. If the container is made available on [DockerHub](https://hub.docker.com/) by TopQuadrant, it would be possible to write a GitHub Action to automatically build and push an image for every new release of `shacl`.
My colleagues and I from the [Swiss Data Science Center - Open Research Data](https://github.com/SDSC-ORD) would be glad to further contribute as we'll be using `shacl` moving forward.