### PR TITLE
Github action to automate Docker image for SHACL API

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,8 +1,7 @@
+ARG VERSION
+
 FROM eclipse-temurin:11 as jre-build
 WORKDIR /app
-
-# Version can be specified at build time
-ARG VERSION=1.4.2
 
 # Annotations to embed in container
 LABEL org.opencontainers.image.title="TopBraid SHACL API"
@@ -34,7 +33,7 @@ RUN unzip shacl.zip && rm shacl.zip
 
 FROM ubuntu:jammy
 
-ARG VERSION=1.4.2
+ARG VERSION
 
 ENV JAVA_HOME=/usr
 ENV PATH "/app/shacl-${VERSION}/bin:${PATH}"

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,7 +1,7 @@
-ARG VERSION
-
 FROM eclipse-temurin:11 as jre-build
 WORKDIR /app
+
+ARG VERSION
 
 # Annotations to embed in container
 LABEL org.opencontainers.image.title="TopBraid SHACL API"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,23 +33,13 @@ jobs:
         # https://github.com/marketplace/actions/get-version
       - name: Get release version
         id: get_version
-        uses: battila7/get-version-action@v2
-        
-        #https://github.com/marketplace/actions/docker-metadata-action
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: type=raw,value=${{ steps.get-version.outputs.version }},enable=${{ github.event_name == 'release' }}
+        uses: reloc8/action-latest-release-version@1.0.0
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
-          context: .
+          context: .docker/
           push: true
           platforms: linux/amd64,linux/arm64
-          file: .docker/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,annotation-index.org.opencontainers.image.description=SHACL API in Java based on Apache Jena 
+          tags: ${{ steps.get_version.outputs.latest-release }}
+          outputs: type=image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,37 +23,41 @@ jobs:
 
         # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
         
         # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98
+        uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # v2.4.0
         
-        # https://github.com/marketplace/actions/get-version
+        # https://github.com/reloc8/action-latest-release-version
       - name: Get release version
         id: get_version
-        uses: reloc8/action-latest-release-version@1.0.0
+        uses: reloc8/action-latest-release-version@b8d6337f30390558e7874a044d6a3c1314314bab # v1.0.0
 
+        # https://github.com/docker/metadata-action
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 #v4.3.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+        # https://github.com/docker/login-action
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+        # https://github.com/docker/build-push-action
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
         with:
           context: .docker/
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.get_version.outputs.latest-release }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ steps.get_version.outputs.latest-release }}
           outputs: type=image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Get release version
         id: get_version
         uses: reloc8/action-latest-release-version@1.0.0
+        
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,7 +34,13 @@ jobs:
       - name: Get release version
         id: get_version
         uses: reloc8/action-latest-release-version@1.0.0
-        
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -49,4 +55,5 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.get_version.outputs.latest-release }}
+          labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,7 +4,7 @@ on:
   release:
     type: [published]
   push:
-    branches: [main]
+    branches: [master]
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,8 @@ name: Create and publish SHACL API Docker image
 on:
   release:
     type: [published]
+  pull_request:
+    branches: [master]
   push:
     branches: [master]
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,10 +32,14 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # v2.4.0
         
-        # https://github.com/reloc8/action-latest-release-version
+        # inspired by https://github.com/reloc8/action-latest-release-version
       - name: Get release version
         id: get_version
-        uses: reloc8/action-latest-release-version@b8d6337f30390558e7874a044d6a3c1314314bab # v1.0.0
+        run: |
+          git fetch --tags
+          git fetch --prune --unshallow || true
+          LATEST_RELEASE=$(git describe --abbrev=0 --tags)
+          echo "latest-release=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
 
         # https://github.com/docker/metadata-action
       - name: Extract metadata (tags, labels) for Docker

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,53 @@
+name: Create and publish SHACL API Docker image
+
+on:
+  release:
+    type: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+        # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        
+        # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98
+        
+        # https://github.com/marketplace/actions/get-version
+      - name: Get release version
+        id: get_version
+        uses: battila7/get-version-action@v2
+        
+        #https://github.com/marketplace/actions/docker-metadata-action
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=raw,value=${{ steps.get-version.outputs.version }},enable=${{ github.event_name == 'release' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          file: .docker/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,annotation-index.org.opencontainers.image.description=SHACL API in Java based on Apache Jena 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,8 @@ name: Create and publish SHACL API Docker image
 on:
   release:
     type: [published]
+  push:
+    branches: [main]
 
 env:
   REGISTRY: ghcr.io

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ The tools print the validation report or the inferences graph to the output scre
 
 ## Dockerfile Usage
 
-The `Dockerfile` in the `.docker` folder includes a minimal Java Runtime Environment for the SHACL API that clocks in at 144Mb. To build the docker imageß use:
+The `Dockerfile` in the `.docker` folder includes a minimal Java Runtime Environment for the SHACL API that clocks in at 144Mb. To build the docker image use:
 
 ```
-docker build -t topquadrant/shacl:1.4.2 .docker/
+docker build -t topquadrant/shacl:1.4.2 --build-arg VERSION=1.4.2 .docker/
 ```
 
 To use the Docker image, there are two possible commands. To run the validator:


### PR DESCRIPTION
Dear Holger,

this PR includes a Github Action to automate the creation and sharing of the SHACL API Docker image. The Github action is triggered for every pull request and push to master and also for every release of the tool. This way the Docker image on Github will always be (automatically) up to date.

By accepting the PR, the current Dockerfile in the repository will not require updates every time there's a new release and docker users will have an easier time using the SHACL API Docker image. The PR uses [Github Packages](https://github.com/features/packages) meaning that TopQuadrant can use its Github account and publish the Docker image on Github. This is an easier solution compared to creating a new account on DockerHub.

From your end we would ask you to do the following:

**Enable public packages**:

1. Go to organization page (github.com/TopQuadrant)
2. Settings
3. Packages
4. Tick the "Public" checkbox under "Package creation"

**Give write permission to github actions**:

1. Go to the repository page(github.com/TopQuadrant/shacl)
2. Settings
3. Actions > General
4. Under "Workflow permissions", set the radio menu to "Read and write permissions"

For any other questions or issues, don't hesitate to reach out.
On behalf of the [SDSC-ORD](https://github.com/SDSC-ORD),
Stefan
