### PR TITLE
Fix and improve docker build action

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get -y update && \
 
 # Compile with maven, extract binaries and copy into image
 COPY . /app
-RUN mvn versions:set -Dversion=${VERSION} -DremoveSnapshot && mvn package -Dmaven.test.skip=true
+RUN mvn versions:set -DnewVersion=${VERSION} && mvn package -Dmaven.test.skip=true
 RUN unzip target/shacl-${VERSION}-bin.zip -d /app/
 
 # BUILD STAGE 2: keep only Java and SHACL

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -70,5 +70,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: VERSION=${{ steps.meta.outputs.tags }}
+          build-args: VERSION=${{ steps.get_version.outputs.version_build }}
           outputs: type=image

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,7 +39,7 @@ jobs:
           
           LATEST_RELEASE=$(git describe --abbrev=0 --tags | sed 's/^v//')
           echo "latest-release=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
-          echo "version_build=${version}_"$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_OUTPUT
+          echo "version_build=${LATEST_RELEASE}_"$(git rev-parse --short "$GITHUB_SHA") >> $GITHUB_OUTPUT
 
         # https://github.com/docker/metadata-action
       - name: Extract metadata (tags, labels) for Docker

--- a/README.md
+++ b/README.md
@@ -86,26 +86,26 @@ The tools print the validation report or the inferences graph to the output scre
 The `Dockerfile` in the `.docker` folder includes a minimal Java Runtime Environment for the SHACL API that clocks in at 144Mb. To build the docker image use:
 
 ```
-docker build -t topquadrant/shacl:1.4.2 --build-arg VERSION=1.4.2 .docker/
+docker build -f .docker/Dockerfile -t ghcr.io/topquadrant/shacl:1.4.2 --build-arg VERSION=1.4.2 .
 ```
 
 To use the Docker image, there are two possible commands. To run the validator:
 
 ```
-docker run --rm -v /path/to/data:/data topquadrant/shacl:1.4.2 validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+docker run --rm -v /path/to/data:/data ghcr.io/topquadrant/shacl:1.4.2 validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
 ```
 
 To run rule inferencing:
 
 ```
-docker run --rm -v /path/to/data:/data topquadrant/shacl:1.4.2 infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+docker run --rm -v /path/to/data:/data ghcr.io/topquadrant/shacl:1.4.2 infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
 ```
 
-Any other command after `topquadrant/shacl:1.4.2` will print the following help page:
+Any other command after `ghcr.io/topquadrant/shacl:1.4.2` will print the following help page:
 
 ```
 Please use this docker image as follows:
-docker run -v /path/to/data:/data topquadrant/shacl:1.4.2 [COMMAND] [PARAMETERS]
+docker run -v /path/to/data:/data ghcr.io/topquadrant/shacl:1.4.2 [COMMAND] [PARAMETERS]
 COMMAND:
 	validate 
 		to run validation


### PR DESCRIPTION
Dear Holger,

Our previous PR (#149)  had an issue with the GitHub action publishing docker images. We were fetching the binaries from maven at build time and mishandled version names. This PR fixes this and improves the action in the following ways:

* Builds the package directly from Github source into the image using `mvn`.
* Proper versioning:
  +  On new GitHub releases, an image named e.g. `ghcr.io/topquadrant/shacl:1.4.3` will be created.
  + On commits, an image named `e.g. ghcr.io/topquadrant/shacl:1.4.3_b8f215a` will be created. (where `b8f215a` is the commit sha)

I apologize for the additional PR, it should work as expected now (the first action will be triggered by the merge commit).

Have an excellent week-end!