### PR TITLE
Update Jena to 4.6.1, and slf4j to 1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <ver.jena>4.3.2</ver.jena>
+    <ver.jena>4.6.1</ver.jena>
     <ver.junit>4.13.2</ver.junit>
-    <ver.slf4j>1.7.30</ver.slf4j>
+    <ver.slf4j>1.7.36</ver.slf4j>
     <ver.log4j2>2.17.1</ver.log4j2>
     <java.version>11</java.version>
   </properties>

--- a/src/main/java/org/topbraid/shacl/expr/lib/FunctionExpression.java
+++ b/src/main/java/org/topbraid/shacl/expr/lib/FunctionExpression.java
@@ -38,7 +38,7 @@ import org.apache.jena.sparql.function.FunctionFactory;
 import org.apache.jena.sparql.function.FunctionRegistry;
 import org.apache.jena.sparql.sse.ItemList;
 import org.apache.jena.sparql.sse.builders.BuilderExpr;
-import org.apache.jena.sparql.sse.builders.ExprBuildException;
+import org.apache.jena.sparql.sse.builders.SSE_ExprBuildException;
 import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.ExprUtils;
 import org.apache.jena.sparql.util.FmtUtils;
@@ -81,7 +81,7 @@ public class FunctionExpression extends ComplexNodeExpression {
 			try {
 				this.expr = BuilderExpr.buildExpr(il);
 			}
-			catch (ExprBuildException ebe) {
+			catch (SSE_ExprBuildException ebe) {
 				throw new IllegalArgumentException("Failed to build expression for " + il, ebe);
 			}
 		}


### PR DESCRIPTION
Didn't update to latest because Jena 4.7.0 removed `RecursiveElementVisitor` and I don't know how to replace it yet.
I think we can split the update in two steps. First merging this PR and then updating to `4.8.0` in a separate one.
I also updated to the latest patch release of slf4j `1.7`.