### PR TITLE
Add support for iterative inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Both tools take the following parameters, for example:
 where `-shapesfile` is optional and falls back to using the data graph as shapes graph.
 Add -validateShapes in case you want to include the metashapes (from the tosh namespace in particular).
 
+For the shaclinfer tool, you can use the `-maxiterations` argument to apply SHACL rule inferencing multiple times; this will add inferred results back to the data graph to see if further triples can be inferred.
+The tool will iterate until either (a) the maximum number of iterations is reached, or (b) no new triples are inferred. The flag is optional and defaults to `1` (single iteration).
+
 Currently only Turtle (.ttl) files are supported.
 
 The tools print the validation report or the inferences graph to the output screen.

--- a/src/main/java/org/topbraid/shacl/tools/AbstractTool.java
+++ b/src/main/java/org/topbraid/shacl/tools/AbstractTool.java
@@ -40,6 +40,8 @@ class AbstractTool {
 	
 	private final static String SHAPES_FILE = "-shapesfile";
 
+	private final static String MAX_ITERATIONS = "-maxiterations";
+
 	
 	private OntDocumentManager dm = new OntDocumentManager();
 	
@@ -67,6 +69,15 @@ class AbstractTool {
 		spec.setDocumentManager(dm);
 	}
 	
+	protected int getMaxIterations(String[] args) {
+		for(int i = 0; i < args.length - 1; i++) {
+			if(MAX_ITERATIONS.equals(args[i])) {
+				return Integer.parseInt(args[i + 1]);
+			}
+		}
+		System.err.println("Missing -maxiterations, e.g.: -maxiterations 100. Defaulting to 1.");
+		return 1;
+	}
 	
 	protected Model getDataModel(String[] args) throws IOException {
 		for(int i = 0; i < args.length - 1; i++) {

--- a/src/main/java/org/topbraid/shacl/tools/AbstractTool.java
+++ b/src/main/java/org/topbraid/shacl/tools/AbstractTool.java
@@ -75,7 +75,6 @@ class AbstractTool {
 				return Integer.parseInt(args[i + 1]);
 			}
 		}
-		System.err.println("Missing -maxiterations, e.g.: -maxiterations 100. Defaulting to 1.");
 		return 1;
 	}
 	

--- a/src/main/java/org/topbraid/shacl/tools/Infer.java
+++ b/src/main/java/org/topbraid/shacl/tools/Infer.java
@@ -53,11 +53,10 @@ public class Infer extends AbstractTool {
 		}
 		int maxIterations = getMaxIterations(args);
 
-		// execute the rules over and over until there are no new results
-		// or until a maximum number of iterations has been reached.
-		// Keep track of all results from each iteration in a separate model.
-		// Break if no new results are found, or if the size of the allResults
-		// model does not increase after a run.
+		// iteratively applies the inference rules until either (a) no new results are found,
+		// or (b) the max iterations is reached. The intermediate inference results are added
+		// to the data model in between each iteration. In addition, all of the inferred triples
+		// are added to a Model object called "results" which is output at the end
 
 		// stores which iteration we are on
 		int iteration = 0;

--- a/src/main/java/org/topbraid/shacl/tools/Infer.java
+++ b/src/main/java/org/topbraid/shacl/tools/Infer.java
@@ -43,15 +43,51 @@ public class Infer extends AbstractTool {
 		System.setErr(oldPS);
 		infer.run(args);
 	}
-	
-	
+
+
 	private void run(String[] args) throws IOException {
 		Model dataModel = getDataModel(args);
 		Model shapesModel = getShapesModel(args);
 		if(shapesModel == null) {
 			shapesModel = dataModel;
 		}
-		Model results = RuleUtil.executeRules(dataModel, shapesModel, null, null);
-		results.write(System.out, FileUtils.langTurtle);
-	}
+        int maxIterations = getMaxIterations(args);
+
+        // execute the rules over and over until there are no new results
+        // or until a maximum number of iterations has been reached.
+        // Keep track of all results from each iteration in a separate model.
+        // Break if no new results are found, or if the size of the allResults
+        // model does not increase after a run.
+
+        // stores which iteration we are on
+        int iteration = 0;
+        // stores all results from each iteration
+        Model results = null;
+        do {
+            // execute the rules
+            Model newResults = RuleUtil.executeRules(dataModel, shapesModel, null, null);
+            // if this is the first iteration, set the results model, otherwise add to it
+            if (results == null) {
+                results = newResults;
+            } else {
+                results.add(newResults);
+            }
+            // if no new results were found, break
+            if (newResults.size() == 0) {
+                break;
+            }
+            // if the size of the allResults model did not increase, break
+            // (this means that the new results were already in the allResults model)
+            if (results.size() == newResults.size()) {
+                break;
+            }
+            // otherwise, continue by adding the new results to the data model, incrementing the iteration,
+            // and continuing the loop to see if more inferences are performed
+            dataModel.add(newResults);
+            iteration++;
+        } while (iteration < maxIterations);
+
+        // print results
+        results.write(System.out, FileUtils.langTurtle);
+    }
 }

--- a/src/main/java/org/topbraid/shacl/tools/Infer.java
+++ b/src/main/java/org/topbraid/shacl/tools/Infer.java
@@ -51,43 +51,48 @@ public class Infer extends AbstractTool {
 		if(shapesModel == null) {
 			shapesModel = dataModel;
 		}
-        int maxIterations = getMaxIterations(args);
+		int maxIterations = getMaxIterations(args);
 
-        // execute the rules over and over until there are no new results
-        // or until a maximum number of iterations has been reached.
-        // Keep track of all results from each iteration in a separate model.
-        // Break if no new results are found, or if the size of the allResults
-        // model does not increase after a run.
+		// execute the rules over and over until there are no new results
+		// or until a maximum number of iterations has been reached.
+		// Keep track of all results from each iteration in a separate model.
+		// Break if no new results are found, or if the size of the allResults
+		// model does not increase after a run.
 
-        // stores which iteration we are on
-        int iteration = 0;
-        // stores all results from each iteration
-        Model results = null;
-        do {
-            // execute the rules
-            Model newResults = RuleUtil.executeRules(dataModel, shapesModel, null, null);
-            // if this is the first iteration, set the results model, otherwise add to it
-            if (results == null) {
-                results = newResults;
-            } else {
-                results.add(newResults);
-            }
-            // if no new results were found, break
-            if (newResults.size() == 0) {
-                break;
-            }
-            // if the size of the allResults model did not increase, break
-            // (this means that the new results were already in the allResults model)
-            if (results.size() == newResults.size()) {
-                break;
-            }
-            // otherwise, continue by adding the new results to the data model, incrementing the iteration,
-            // and continuing the loop to see if more inferences are performed
-            dataModel.add(newResults);
-            iteration++;
-        } while (iteration < maxIterations);
+		// stores which iteration we are on
+		int iteration = 0;
+		// stores all results from each iteration
+		Model results = null;
+		do {
+			// execute the rules
+			Model newResults = RuleUtil.executeRules(dataModel, shapesModel, null, null);
+			// if this is the first iteration, set the results model, otherwise add to it
+			if (results == null) {
+				results = newResults;
+			} else {
+				results.add(newResults);
+			}
+			// if no new results were found, break
+			if (newResults.size() == 0) {
+				break;
+			}
+			// if the size of the allResults model did not increase, break
+			// (this means that the new results were already in the allResults model)
+			if (results.size() == newResults.size()) {
+				break;
+			}
 
-        // print results
-        results.write(System.out, FileUtils.langTurtle);
-    }
+			// if there is at least 1 more iteration, then we need to add the new results
+			// to the data model and continue the loop
+			if (iteration < maxIterations - 1) {
+				dataModel.add(newResults);
+			}
+
+			// always increment the iteration counter
+			iteration++;
+		} while (iteration < maxIterations);
+
+		// print results
+		results.write(System.out, FileUtils.langTurtle);
+	}
 }


### PR DESCRIPTION
Adds a new flag, `-maxiterations` which takes an integer argument. This defaults to '1' (which was the existing behavior). The new Infer implementation performs the inference until either (a) the required nubmer of iterations is hit, or (b) there are no new inferences produced. Resolves #162 

@HolgerKnublauch I didn't see any CONTRIBUTING document so let me know if there's anything you'd like me to add here. Is there a particular test file I should be adding some calls to? Linters/checkers you want me to run?

Thanks in advance!