### PR TITLE
job build-and-push-image: fix step "Get release version"

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Get release version
         id: get_version
         run: |
-          git fetch --tags
+          git fetch --tags -f
           git fetch --prune --unshallow || true
           
           LATEST_RELEASE=$(git describe --abbrev=0 --tags | sed 's/^v//')


### PR DESCRIPTION
This PR fixes the Docker Image build pipeline, which currently fails if running for a release: https://github.com/TopQuadrant/shacl/actions/runs/8158088088/job/22299199531#step:6:1

Please consider making an immediate hot-fix release (1.4.4) after merging, to make the docker image available.