### PR TITLE
Update Github Action and README

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
-          name: digests-{{ matrix.package }}
+          name: digests-${{ matrix.package }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -90,12 +90,13 @@ jobs:
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"          
+          touch "/tmp/digests/${digest#sha256:}"  
+          tar cvf artifacts.tar /tmp/digests        
       - name: Upload digest
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
           name: digests
-          path: /tmp/digests/*
+          path: artifacts.tar
           if-no-files-found: error
           retention-days: 1
 
@@ -127,7 +128,8 @@ jobs:
           uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 #v4.1.4
           with:
             name: digests
-            path: /tmp/digests
+            path: artifacts.tar
+        - run: tar xf artifacts.tar
           # https://github.com/docker/setup-buildx-action
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,10 +17,17 @@ jobs:
       packages: write
     strategy:
       matrix:
+        package:
+          [
+            "x86_64",
+            "arm64"
+          ]
         include:
-          - platform: linux/amd64
+          - package: "x86_64"
+            platform: linux/amd64
             base: eclipse-temurin:11-alpine
-          - platform: linux/arm64
+          - package: "arm64"
+            platform: linux/arm64
             base: amazoncorretto:11-alpine3.18-jdk
 
     steps:
@@ -90,13 +97,12 @@ jobs:
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"  
-          tar cvf artifacts.tar /tmp/digests        
+          touch "/tmp/digests/${digest#sha256:}"     
       - name: Upload digest
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
-          name: digests
-          path: artifacts.tar
+          name: digests-{{ matrix.package }}
+          path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
@@ -127,9 +133,8 @@ jobs:
         - name: Download digests
           uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 #v4.1.4
           with:
-            name: digests
-            path: artifacts.tar
-        - run: tar xf artifacts.tar
+            pattern: digests-*
+            merge-multiple: true
           # https://github.com/docker/setup-buildx-action
         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -133,6 +133,7 @@ jobs:
         - name: Download digests
           uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 #v4.1.4
           with:
+            path: /tmp/digests
             pattern: digests-*
             merge-multiple: true
           # https://github.com/docker/setup-buildx-action

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -29,16 +29,16 @@ jobs:
           echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
           
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
         # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
         
         # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # v2.4.0
+        uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
         
         # inspired by https://github.com/reloc8/action-latest-release-version
       - name: Get release version
@@ -54,7 +54,7 @@ jobs:
         # https://github.com/docker/metadata-action
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 #v4.3.0
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -65,7 +65,7 @@ jobs:
 
         # https://github.com/docker/login-action
       - name: Log in to the Container registry
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -74,7 +74,7 @@ jobs:
         # https://github.com/docker/build-push-action
       - name: Build and push Docker image for x86 and arm64
         id: build
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 #v4.0.0
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 #v5.3.0
         with:
           file: .docker/Dockerfile
           push: true
@@ -92,7 +92,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"          
       - name: Upload digest
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
           name: digests
           path: /tmp/digests/*
@@ -124,17 +124,18 @@ jobs:
           
           # https://github.com/actions/download-artifact
         - name: Download digests
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 #v4.1.4
           with:
             name: digests
             path: /tmp/digests
+          # https://github.com/docker/setup-buildx-action
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
+          uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3.2.0
 
           # https://github.com/docker/metadata-action
         - name: Extract metadata (tags, labels) for Docker
           id: meta
-          uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96 #v4.3.0
+          uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #v5.5.1
           with:
             images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             tags: |
@@ -144,7 +145,7 @@ jobs:
 
           # https://github.com/docker/login-action
         - name: Log in to the Container registry
-          uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+          uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
           with:
             registry: ${{ env.REGISTRY }}
             username: ${{ github.actor }}

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To use them, set up your environment similar to https://jena.apache.org/document
 For example, on Windows:
 
 ```
-SET SHACLROOT=C:\Users\Holger\Desktop\shacl-1.4.2-bin
+SET SHACLROOT=C:\Users\Holger\Desktop\shacl-1.4.3-bin
 SET PATH=%PATH%;%SHACLROOT%\bin
 ```
 
@@ -68,7 +68,7 @@ As another example, for Linux, add to .bashrc these lines:
 
 ```
 # for shacl
-export SHACLROOT=/home/holger/shacl/shacl-1.4.2-bin/shacl-1.4.2/bin
+export SHACLROOT=/home/holger/shacl/shacl-1.4.3-bin/shacl-1.4.3/bin
 export PATH=$SHACLROOT:$PATH 
 ```
 
@@ -91,27 +91,27 @@ The tools print the validation report or the inferences graph to the output scre
 The `Dockerfile` in the `.docker` folder includes a minimal Java Runtime Environment for the SHACL API that clocks in at ~85Mb. To get the latest release of the image use:
 
 ```
-docker build -f .docker/Dockerfile -t ghcr.io/topquadrant/shacl:1.4.2 --build-arg VERSION=1.4.2 .
+docker build -f .docker/Dockerfile -t ghcr.io/topquadrant/shacl:1.4.3 --build-arg VERSION=1.4.3 .
 ```
 > :warning: It is generally better to use a fixed version of the docker image, rather than the `latest` tag. Consult the package page to find what versions are available.
 
 To use the Docker image, there are two possible commands. To run the validator:
 
 ```
-docker run --rm -v /path/to/data:/data ghcr.io/topquadrant/shacl:1.4.2 validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+docker run --rm -v /path/to/data:/data ghcr.io/topquadrant/shacl:1.4.3 validate -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
 ```
 
 To run rule inferencing:
 
 ```
-docker run --rm -v /path/to/data:/data ghcr.io/topquadrant/shacl:1.4.2 infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
+docker run --rm -v /path/to/data:/data ghcr.io/topquadrant/shacl:1.4.3 infer -datafile /data/myfile.ttl -shapesfile /data/myshapes.ttl
 ```
 
-Any other command after `ghcr.io/topquadrant/shacl:1.4.2` will print the following help page:
+Any other command after `ghcr.io/topquadrant/shacl:1.4.3` will print the following help page:
 
 ```
 Please use this docker image as follows:
-docker run -v /path/to/data:/data ghcr.io/topquadrant/shacl:1.4.2 [COMMAND] [PARAMETERS]
+docker run -v /path/to/data:/data ghcr.io/topquadrant/shacl:1.4.3 [COMMAND] [PARAMETERS]
 COMMAND:
 	validate 
 		to run validation
@@ -127,11 +127,11 @@ PARAMETERS:
 If you'd like to build the image locally in an `x86` architecture, use:
 
 ```
-docker build -f .docker/Dockerfile -t ghcr.io/topquadrant/shacl:1.4.2 --build-arg VERSION=1.4.2 --build-arg ARCH_BASE=eclipse-temurin:11-alpine .
+docker build -f .docker/Dockerfile -t ghcr.io/topquadrant/shacl:1.4.3 --build-arg VERSION=1.4.3 --build-arg ARCH_BASE=eclipse-temurin:11-alpine .
 ```
 
 If your architecture is `arm`, use:
 
 ```
-docker build -f .docker/Dockerfile -t ghcr.io/topquadrant/shacl:1.4.2 --build-arg VERSION=1.4.2 --build-arg ARCH_BASE=amd64/eclipse-temurin:11-alpine .
+docker build -f .docker/Dockerfile -t ghcr.io/topquadrant/shacl:1.4.3 --build-arg VERSION=1.4.3 --build-arg ARCH_BASE=amazoncorretto:11-alpine3.18-jdk .
 ```


### PR DESCRIPTION
Dear @ashleycaselli,

thank you for taking over the SHACL API repository and doing such a tidy job for the new release :)

In this PR I'm changing the README as follows:

- update all mentions of 1.4.2 to 1.4.3
- minor fix on the `arm` base image when building a local Dockerfile

The PR also includes changes to the Github Action file as follows:

 - update all Actions to their latest version (this addresses a deprecation warning related to [Github transitioning to a new node](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/))
 - small refactoring of the actions related to download/upload of artifacts (inspired by [this reply](https://github.com/actions/upload-artifact/issues/478#issuecomment-2016557414) from [this issue](https://github.com/actions/upload-artifact/issues/478))