### PR TITLE
Enhanced maintenance: GH workflow and dependency automation

### DIFF
--- a/.github/workflows/maven-test-pr.yml
+++ b/.github/workflows/maven-test-pr.yml
@@ -1,0 +1,19 @@
+name: Maven Test
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - name: Set up JDK
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        with:
+          java-version: "11"
+          distribution: "temurin"
+
+      - name: Test with Maven
+        run: mvn -B test

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "local>ashleycaselli/renovate-config"
+    ],
+    "automerge": false,
+    "packageRules": [
+        {
+            "description": "Updates to the parent dependencies should trigger a new patch release",
+            "matchPaths": [
+                "pom.xml"
+            ],
+            "semanticCommitType": "chore",
+            "semanticCommitScope": "core-deps"
+        },
+        {
+            "description": "Updates to the dependencies under the build settings element should not trigger any release",
+            "matchPaths": [
+                "pom.xml"
+            ],
+            "matchDepTypes": [
+                "build"
+            ],
+            "semanticCommitType": "build",
+            "semanticCommitScope": "deps"
+        },
+        {
+            "description": "Updates to the dependencies with scope 'test' should be tagged as 'test(deps)'",
+            "matchPaths": [
+                "pom.xml"
+            ],
+            "matchDepTypes": [
+                "test"
+            ],
+            "semanticCommitType": "test",
+            "semanticCommitScope": "deps"
+        }
+    ]
+}


### PR DESCRIPTION
This PR contains changes that improve maintenance tasks

- adds GitHub workflow for running Maven tests on PRs (speeding up the PR review process)
- adds the configuration for [Mend Renovate](https://www.mend.io/renovate/) to automate the dependencies updates. Currently, the tool only works on my fork but I'm planning to keep this repository synchronized manually