### PR TITLE
Pushed Jena version to 5.0.0 and updated Caching library

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,10 +25,10 @@ jobs:
         include:
           - package: "x86_64"
             platform: linux/amd64
-            base: eclipse-temurin:11-alpine
+            base: eclipse-temurin:17-alpine
           - package: "arm64"
             platform: linux/arm64
-            base: amazoncorretto:11-alpine3.18-jdk
+            base: amazoncorretto:17-alpine3.18-jdk
 
     steps:
       - name: lowercase image name

--- a/.github/workflows/maven-test-pr.yml
+++ b/.github/workflows/maven-test-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
         with:
-          java-version: "11"
+          java-version: "17"
           distribution: "temurin"
 
       - name: Test with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <ver.jena>4.10.0</ver.jena>
+    <ver.jena>5.0.0</ver.jena>
     <ver.junit>4.13.2</ver.junit>
     <ver.slf4j>1.7.36</ver.slf4j>
     <ver.log4j2>2.20.0</ver.log4j2>

--- a/src/main/java/org/topbraid/jenax/functions/AbstractFunction.java
+++ b/src/main/java/org/topbraid/jenax/functions/AbstractFunction.java
@@ -31,6 +31,7 @@ import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.function.Function;
 import org.apache.jena.sparql.function.FunctionEnv;
 import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.FmtUtils;
 import org.topbraid.jenax.statistics.ExecStatistics;
 import org.topbraid.jenax.statistics.ExecStatisticsManager;
@@ -44,9 +45,7 @@ import org.topbraid.jenax.statistics.ExecStatisticsManager;
 public abstract class AbstractFunction implements Function {
 
 	@Override
-    public void build(String uri, ExprList args) {
-	}
-
+	public void build(String var1, ExprList var2, Context var3){}
 	
 	@Override
     public NodeValue exec(Binding binding, ExprList args, String uri, FunctionEnv env) {

--- a/src/main/java/org/topbraid/jenax/functions/AbstractFunction.java
+++ b/src/main/java/org/topbraid/jenax/functions/AbstractFunction.java
@@ -46,7 +46,7 @@ public abstract class AbstractFunction implements Function {
 
 	@Override
 	public void build(String var1, ExprList var2, Context var3){}
-	
+
 	@Override
     public NodeValue exec(Binding binding, ExprList args, String uri, FunctionEnv env) {
 		Node[] nodes = new Node[args.size()];

--- a/src/main/java/org/topbraid/jenax/util/JenaUtil.java
+++ b/src/main/java/org/topbraid/jenax/util/JenaUtil.java
@@ -30,6 +30,7 @@ import java.util.function.BiFunction;
 
 import org.apache.jena.enhanced.EnhGraph;
 import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.compose.MultiUnion;
 import org.apache.jena.ontology.OntModel;
@@ -71,7 +72,6 @@ import org.apache.jena.sparql.expr.ExprVar;
 import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
 import org.apache.jena.sparql.function.FunctionEnv;
-import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.sparql.graph.NodeTransform;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransform;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformSubst;
@@ -318,7 +318,7 @@ public class JenaUtil {
 	 * @return a new memory graph
 	 */
 	public static Graph createMemoryGraph() {
-		return GraphFactory.createDefaultGraph();
+		return GraphMemFactory.createDefaultGraph();
 	}
 	
 	

--- a/src/main/java/org/topbraid/jenax/util/JenaUtil.java
+++ b/src/main/java/org/topbraid/jenax/util/JenaUtil.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 
 import org.apache.jena.enhanced.EnhGraph;
-import org.apache.jena.graph.Factory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.compose.MultiUnion;
@@ -72,12 +71,14 @@ import org.apache.jena.sparql.expr.ExprVar;
 import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
 import org.apache.jena.sparql.function.FunctionEnv;
+import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.sparql.graph.NodeTransform;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransform;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformSubst;
 import org.apache.jena.sparql.syntax.syntaxtransform.ExprTransformNodeElement;
 import org.apache.jena.sparql.syntax.syntaxtransform.QueryTransformOps;
 import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sparql.util.NodeCmp;
 import org.apache.jena.sparql.util.NodeFactoryExtra;
 import org.apache.jena.sparql.util.NodeUtils;
 import org.apache.jena.util.iterator.ExtendedIterator;
@@ -317,7 +318,7 @@ public class JenaUtil {
 	 * @return a new memory graph
 	 */
 	public static Graph createMemoryGraph() {
-		return Factory.createDefaultGraph();
+		return GraphFactory.createDefaultGraph();
 	}
 	
 	
@@ -1240,7 +1241,7 @@ public class JenaUtil {
 		Collections.sort(nodes, new Comparator<Resource>() {
 			@Override
 			public int compare(Resource o1, Resource o2) {
-		        return NodeUtils.compareRDFTerms(o1.asNode(), o2.asNode());
+		        return NodeCmp.compareRDFTerms(o1.asNode(), o2.asNode());
 			}
 		});
 	}

--- a/src/main/java/org/topbraid/jenax/util/JenaUtilHelper.java
+++ b/src/main/java/org/topbraid/jenax/util/JenaUtilHelper.java
@@ -18,7 +18,6 @@ package org.topbraid.jenax.util;
 
 import java.util.Iterator;
 
-import org.apache.jena.graph.Factory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.compose.MultiUnion;
 import org.apache.jena.mem.GraphMemBase;
@@ -26,6 +25,7 @@ import org.apache.jena.ontology.OntModel;
 import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.sparql.graph.GraphFactory;
 
 /**
  * This is an extension point for the SPIN library
@@ -72,7 +72,7 @@ public class JenaUtilHelper {
 	 * @return the default Graph
 	 */
 	public Graph createDefaultGraph() {
-		return Factory.createDefaultGraph();
+		return GraphFactory.createDefaultGraph();
 	}
 
 	

--- a/src/main/java/org/topbraid/shacl/arq/SHACLARQFunction.java
+++ b/src/main/java/org/topbraid/shacl/arq/SHACLARQFunction.java
@@ -102,11 +102,6 @@ public abstract class SHACLARQFunction implements org.apache.jena.sparql.functio
 		}
 	}
 	
-
-    public void build(String uri, ExprList args) {
-	}
-
-	
 	@Override
     public org.apache.jena.sparql.function.Function create(String uri) {
 		return this;

--- a/src/main/java/org/topbraid/shacl/arq/SHACLARQFunction.java
+++ b/src/main/java/org/topbraid/shacl/arq/SHACLARQFunction.java
@@ -103,7 +103,6 @@ public abstract class SHACLARQFunction implements org.apache.jena.sparql.functio
 	}
 	
 
-	@Override
     public void build(String uri, ExprList args) {
 	}
 

--- a/src/main/java/org/topbraid/shacl/arq/functions/SHACLSPARQLARQFunction.java
+++ b/src/main/java/org/topbraid/shacl/arq/functions/SHACLSPARQLARQFunction.java
@@ -29,6 +29,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.expr.ExprEvalException;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.util.Context;
 import org.topbraid.jenax.util.ARQFactory;
 import org.topbraid.jenax.util.DatasetWithDifferentDefaultModel;
 import org.topbraid.jenax.util.JenaUtil;
@@ -54,7 +55,10 @@ public class SHACLSPARQLARQFunction extends SHACLARQFunction {
 	private org.apache.jena.query.Query arqQuery;
 	
 	private String queryString;
-	
+
+	@Override
+	public void build(String var1, ExprList var2, Context var3) {
+	}
 
 	/**
 	 * Constructs a new SHACLSPARQLARQFunction based on a given sh:ConstraintComponent

--- a/src/main/java/org/topbraid/shacl/arq/functions/SHACLSPARQLARQFunction.java
+++ b/src/main/java/org/topbraid/shacl/arq/functions/SHACLSPARQLARQFunction.java
@@ -110,11 +110,6 @@ public class SHACLSPARQLARQFunction extends SHACLARQFunction {
 
 		addParameters(shaclFunction);
 	}
-	
-
-	@Override
-    public void build(String uri, ExprList args) {
-	}
 
 	
 	@Override

--- a/src/main/java/org/topbraid/shacl/util/SHACLUtil.java
+++ b/src/main/java/org/topbraid/shacl/util/SHACLUtil.java
@@ -503,7 +503,7 @@ public class SHACLUtil {
 		String key = OntologyOptimizations.get().getKeyIfEnabledFor(clsOrShape.getModel().getGraph());
 		if(key != null) {
 			key += ".getAllShapesAtClassOrShape(" + clsOrShape + ")";
-			return (List<SHNodeShape>) OntologyOptimizations.get().getOrComputeObject(key, () -> {				
+			return (List<SHNodeShape>) OntologyOptimizations.get().getOrComputeObject(key, (cacheKey) -> {
 				List<SHNodeShape> results = new LinkedList<SHNodeShape>();
 				addAllShapesAtClassOrShape(clsOrShape, results, new HashSet<Resource>());
 				return results;
@@ -515,8 +515,9 @@ public class SHACLUtil {
 			return results;
 		}
 	}
-	
-	
+
+
+
 	private static void addAllShapesAtClassOrShape(Resource clsOrShape, List<SHNodeShape> results, Set<Resource> reached) {
 		addDirectShapesAtClassOrShape(clsOrShape, results);
 		reached.add(clsOrShape);


### PR DESCRIPTION
Hi,

I was having trouble using 1.4.3 due to Jena classes deprecated or removed - more specifically org.apache.jena.graph.Factory. In my pull request, i've updated Jena to the latest version and also updated the Caching library to use benmanes (https://github.com/ben-manes/caffeine) which is compatible with the previously used library. I believe that the library used in the main fork is not available anymore.

Thanks,
Jeremy

PS. I couldn't assign anyone as reviewer. I guess Holger or Ashley can do this.