### PR TITLE
Hide stacktrace for unexpected errors included in the validation report

### DIFF
--- a/src/main/java/org/topbraid/shacl/validation/ValidationEngine.java
+++ b/src/main/java/org/topbraid/shacl/validation/ValidationEngine.java
@@ -612,7 +612,7 @@ public class ValidationEngine extends AbstractEngine {
 		}
 		catch(Exception ex) {
 			Resource result = createResult(DASH.FailureResult, constraint, constraint.getShapeResource());
-			result.addProperty(SH.resultMessage, "Failed to create validator: " + ExceptionUtil.getStackTrace(ex));
+			result.addProperty(SH.resultMessage, "Failed to create validator: " + ex.getMessage());
 			return;
 		}
 		if(executor != null) {
@@ -622,7 +622,7 @@ public class ValidationEngine extends AbstractEngine {
 				}
 				catch(Exception ex) {
 					Resource result = createResult(DASH.FailureResult, constraint, constraint.getShapeResource());
-					result.addProperty(SH.resultMessage, "Exception during validation: " + ExceptionUtil.getStackTrace(ex));
+					result.addProperty(SH.resultMessage, "Exception during validation: " + ex.getMessage());
 				}
 			}
 			else {

--- a/src/main/java/org/topbraid/shacl/validation/ValidationEngine.java
+++ b/src/main/java/org/topbraid/shacl/validation/ValidationEngine.java
@@ -612,7 +612,7 @@ public class ValidationEngine extends AbstractEngine {
 		}
 		catch(Exception ex) {
 			Resource result = createResult(DASH.FailureResult, constraint, constraint.getShapeResource());
-			result.addProperty(SH.resultMessage, "Failed to create validator: " + ex.getMessage());
+			result.addProperty(SH.resultMessage, "Failed to create validator: " + ExceptionUtil.getDeepMessage(ex));
 			return;
 		}
 		if(executor != null) {
@@ -622,7 +622,7 @@ public class ValidationEngine extends AbstractEngine {
 				}
 				catch(Exception ex) {
 					Resource result = createResult(DASH.FailureResult, constraint, constraint.getShapeResource());
-					result.addProperty(SH.resultMessage, "Exception during validation: " + ex.getMessage());
+					result.addProperty(SH.resultMessage, "Exception during validation: " + ExceptionUtil.getDeepMessage(ex));
 				}
 			}
 			else {


### PR DESCRIPTION
When an exception is raised during validation for specific rules, the current implementation includes as part of the reported violation the full stack trace of the error. This results in unnecessarily long reported errors, which also expose implementation details to the client/user.

This PR makes a small adaptation to only include the message of the exception (without the stack trace), which should contain whatever information is meaningful for the validation report. In practice, before this update an exception-related violation in the report would be reported as:
```
  sh:result    [ rdf:type                      dash:FailureResult;
                 sh:focusNode                  bsh:DeprecationRuleForInstances;
                 sh:resultMessage              "Failed to create validator: org.topbraid.shacl.validation.SHACLException: Invalid SPARQL constraint (Line 1, column 28: Unresolved prefixed name: rdf:type):\nSELECT $this WHERE { $this rdf:type/owl:deprecated true }\r\n\tat org.topbraid.shacl.validation.sparql.AbstractSPARQLExecutor.<init>(AbstractSPARQLExecutor.java:75)\r\n\tat org.topbraid.shacl.validation.sparql.SPARQLConstraintExecutor.<init>(SPARQLConstraintExecutor.java:53)\r\n\tat org.topbraid.shacl.validation.ConstraintExecutors.lambda$new$2(ConstraintExecutors.java:54)\r\n\tat org.topbraid.shacl.validation.ConstraintExecutors.getExecutor(ConstraintExecutors.java:77)\r\n\tat org.topbraid.shacl.engine.Constraint.getExecutor(Constraint.java:105)\r\n\tat org.topbraid.shacl.validation.ValidationEngine.validateNodesAgainstConstraint(ValidationEngine.java:611)\r\n\tat org.topbraid.shacl.validation.ValidationEngine.validateShapes(ValidationEngine.java:582)\r\n\tat org.topbraid.shacl.validation.ValidationEngine.validateAll(ValidationEngine.java:482)\r\n\tat org.topbraid.shacl.validation.ValidationUtil.validateModel(ValidationUtil.java:123)\r\n\tat org.topbraid.shacl.validation.ValidationUtil.validateModel(ValidationUtil.java:104)\r\n\tat org.topbraid.shacl.tools.Validate.run(Validate.java:60)\r\n\tat org.topbraid.shacl.tools.Validate.main(Validate.java:48)\r\n";
                 sh:resultSeverity             sh:Warning;
                 sh:sourceConstraintComponent  sh:SPARQLConstraintComponent;
                 sh:sourceShape                bsh:DeprecationRuleForInstances
               ];
```
Whereas with this update it is reported as:
```
  sh:result    [ rdf:type                      dash:FailureResult;
                 sh:focusNode                  bsh:DeprecationRuleForInstances;
                 sh:resultMessage              "Failed to create validator: Invalid SPARQL constraint (Line 1, column 28: Unresolved prefixed name: rdf:type):\nSELECT $this WHERE { $this rdf:type/owl:deprecated true }";
                 sh:resultSeverity             sh:Warning;
                 sh:sourceConstraintComponent  sh:SPARQLConstraintComponent;
                 sh:sourceShape                bsh:DeprecationRuleForInstances
               ];
```
Would it be possible to merge this and publish a patch release? Thanks!