### PR TITLE
Bump Jena version to 5.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <ver.jena>5.2.0</ver.jena>
+    <ver.jena>5.3.0</ver.jena>
     <ver.junit>4.13.2</ver.junit>
     <ver.slf4j>2.0.16</ver.slf4j>
     <ver.log4j2>2.24.3</ver.log4j2>

--- a/src/main/java/org/topbraid/shacl/validation/java/PatternConstraintExecutor.java
+++ b/src/main/java/org/topbraid/shacl/validation/java/PatternConstraintExecutor.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 import java.util.regex.Pattern;
 
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.sparql.expr.RegexJava;
+import org.apache.jena.sparql.expr.RegexEngine;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
 import org.topbraid.jenax.util.JenaUtil;
 import org.topbraid.shacl.engine.Constraint;
@@ -29,7 +29,7 @@ class PatternConstraintExecutor extends AbstractNativeConstraintExecutor {
 	PatternConstraintExecutor(Constraint constraint) {
 		flagsStr = JenaUtil.getStringProperty(constraint.getShapeResource(), SH.flags);
 		patternString = JenaUtil.getStringProperty(constraint.getShapeResource(), SH.pattern);
-        int flags = RegexJava.makeMask(flagsStr);
+        int flags = RegexEngine.makeMask(flagsStr);
         if (flagsStr != null && flagsStr.contains("q")) {
             patternString = Pattern.quote(patternString);
         }


### PR DESCRIPTION
This PR updates the Jena dependency to 5.3 and replace `RegexJava` by `RegexEngine` following the changes introduced in: https://github.com/apache/jena/pull/2834