### PR TITLE
Upgrade to Jena v5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <ver.jena>5.2.0</ver.jena>
+    <ver.jena>5.4.0</ver.jena>
     <ver.junit>4.13.2</ver.junit>
     <ver.slf4j>2.0.17</ver.slf4j>
     <ver.log4j2>2.24.3</ver.log4j2>

--- a/src/main/java/org/topbraid/jenax/util/QueryExecutionFactoryFilter.java
+++ b/src/main/java/org/topbraid/jenax/util/QueryExecutionFactoryFilter.java
@@ -60,7 +60,7 @@ public class QueryExecutionFactoryFilter {
         return QueryExecution.create()
                 .query(query)
                 .model(model)
-                .initialBinding(initialBinding)
+                .substitution(initialBinding)
                 .build();
     }
 

--- a/src/main/java/org/topbraid/shacl/arq/functions/IsValidLangTagFunction.java
+++ b/src/main/java/org/topbraid/shacl/arq/functions/IsValidLangTagFunction.java
@@ -1,7 +1,7 @@
 package org.topbraid.shacl.arq.functions;
 
 import org.apache.jena.graph.Node;
-import org.apache.jena.riot.web.LangTag;
+import org.apache.jena.langtagx.LangTagX;
 import org.apache.jena.sparql.expr.ExprEvalException;
 import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.function.FunctionEnv;
@@ -19,6 +19,6 @@ public class IsValidLangTagFunction extends AbstractFunction1 {
 		if(arg == null || !arg.isLiteral()) {
 			throw new ExprEvalException("Argument must be a (string) literal");
 		}
-		return NodeValue.makeBoolean(LangTag.check(arg.getLiteralLexicalForm()));
+		return NodeValue.makeBoolean(LangTagX.checkLanguageTag(arg.getLiteralLexicalForm()));
 	}
 }

--- a/src/main/java/org/topbraid/shacl/validation/java/PatternConstraintExecutor.java
+++ b/src/main/java/org/topbraid/shacl/validation/java/PatternConstraintExecutor.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 import java.util.regex.Pattern;
 
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.sparql.expr.RegexJava;
+import org.apache.jena.sparql.expr.RegexEngine;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
 import org.topbraid.jenax.util.JenaUtil;
 import org.topbraid.shacl.engine.Constraint;
@@ -29,7 +29,7 @@ class PatternConstraintExecutor extends AbstractNativeConstraintExecutor {
 	PatternConstraintExecutor(Constraint constraint) {
 		flagsStr = JenaUtil.getStringProperty(constraint.getShapeResource(), SH.flags);
 		patternString = JenaUtil.getStringProperty(constraint.getShapeResource(), SH.pattern);
-        int flags = RegexJava.makeMask(flagsStr);
+        int flags = RegexEngine.RegexJava.makeMask(flagsStr);
         if (flagsStr != null && flagsStr.contains("q")) {
             patternString = Pattern.quote(patternString);
         }


### PR DESCRIPTION
Upgraded to Jena v5.4.0. Changes needed in the code were as follows:

- Minor change to match refactoring since v5.2.0.
- Minor code adaptation to resolve deprecation warnings.